### PR TITLE
Add support for more candid types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/aviate-labs/secp256k1 v0.0.0-5e6736a // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/di-wu/parser v0.3.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/internal/provider/arg.go
+++ b/internal/provider/arg.go
@@ -1,0 +1,109 @@
+// Copyright (c) DFINITY Foundation
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Takes a terraform value and tries to convert it to a value that can be serialized
+// as candid.
+// Heuristics:
+//   - If the value is an object with fields __didType & __didValue, use __didType
+//     as the type for __didValue
+//   - Otherwise, use the corresponding candid value (candid 'text' for Terraform strings,
+//     candid 'record' for Terraform objects, etc)
+func TFValToCandid(val tftypes.Value) (any, error) {
+
+	// First, we try to read a wrapped value ( { __didType = ..., __didValue = ... })
+	res, errWrapped := readWrappedValue(val)
+	if errWrapped == nil {
+		return res, nil
+	}
+
+	// Otherwise, try to read the value as unwrapped values (the order doesn't really matter)
+	res, errText := readTextValue(val)
+	if errText == nil {
+		return res, nil
+	}
+
+	res, errRec := readRecordValue(val)
+	if errRec == nil {
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("cannot encode value %v: %w; %w; %w", val.String(), errWrapped, errText, errRec)
+}
+
+// Read a wrapped value. Returns an error if not a wrapped value (i.e. if does not contain
+// __didType & __didValue).
+func readWrappedValue(val tftypes.Value) (any, error) {
+	var m map[string]tftypes.Value
+
+	err := val.As(&m)
+	if err != nil {
+		return nil, fmt.Errorf("not a wrapped value: %w (%v)", err, val)
+	}
+
+	idlType, ok := m["__didType"]
+
+	if !ok {
+		return nil, fmt.Errorf("not a wrapped value: no __didType: %v", val)
+	}
+
+	idlValue, ok := m["__didValue"]
+	if !ok {
+		return nil, fmt.Errorf("not a wrapped value: no __didValue: %v", val)
+	}
+
+	ty, err := readTextValue(idlType) // XXX: Hack to read the TF value as a Golang string
+	if err != nil {
+		return nil, fmt.Errorf("__didType not a string: %v", val.String())
+	}
+
+	// NOTE: Here we explicitly specify the primitive type (text, record, ...) as we
+	// do _not_ want to read the value as a wrapper (even if it contains __didType &
+	// __didValue).
+	switch ty {
+	case "text":
+		return readTextValue(idlValue)
+	case "record":
+		return readRecordValue(idlValue)
+
+	default:
+		return nil, fmt.Errorf("unknown idl type %s for val %v", idlType.String(), val)
+	}
+}
+
+// read 'val' as a text value.
+func readTextValue(val tftypes.Value) (string, error) {
+	var str string
+	err := val.As(&str)
+	if err == nil {
+		return str, nil
+	}
+
+	return "", fmt.Errorf("not a string: %v", val)
+}
+
+// read 'val' as a record value.
+func readRecordValue(val tftypes.Value) (map[string]any, error) {
+	var m map[string]tftypes.Value
+
+	err := val.As(&m)
+	if err != nil {
+		return nil, fmt.Errorf("not a record: %s", val.String())
+	}
+	ret := make(map[string]any)
+	for k, v := range m {
+		ret[k], err = TFValToCandid(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ret, nil
+
+}

--- a/internal/provider/arg_encode_function.go
+++ b/internal/provider/arg_encode_function.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"context"
+	"encoding/hex"
+	"github.com/aviate-labs/agent-go/candid/idl"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+const argEncodeSummary = "Encode Terraform values into candid values."
+
+const argEncodeDescription = "The `did_encode` function transforms Terraform values into hex-encoded candid values. It takes a single argument and applies heuristics to generate a candid value. \n" +
+
+	"For primitive values (strings, etc) will be encoded as the equivalent candid type. HCL maps and objects will be encoded as records unless they contain the fields `__didType` or `__didValue`. When those fields are set, `__didValue` is the actual value to be encoded, and `__didType` must be a tag defining the type of the value. These fields however should be treated as implementation details and the various helpers (`did_text`, `did_record`) should be used instead. \n\n" +
+
+	"Here are some equivalences between HCL values and textual candid value: \n\n" +
+
+	"`" + `"hello"` + "` = `" + `("hello")` + "`" + "\n" +
+	"`" + `{ foo = "bar" }` + "` = `" + `(record { foo = "bar" })` + "`" + "\n"
+
+// Ensure the implementation satisfies the desired interfaces.
+var _ function.Function = &ArgEncodeFunction{}
+
+type ArgEncodeFunction struct{}
+
+func (f *ArgEncodeFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "did_encode"
+}
+
+func (f *ArgEncodeFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+
+	resp.Definition = function.Definition{
+		Summary:             argEncodeSummary,
+		Description:         argEncodeDescription,
+		MarkdownDescription: argEncodeDescription,
+
+		Parameters: []function.Parameter{
+			function.DynamicParameter{
+				Name:        "input",
+				Description: "The HCL value to candid-encode",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f *ArgEncodeFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var input attr.Value
+
+	// Read Terraform argument data into the variable
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &input))
+	if resp.Error != nil {
+		return
+	}
+
+	tfValue, err := input.ToTerraformValue(ctx)
+	if err != nil {
+		resp.Error = function.NewFuncError(err.Error())
+		return
+	}
+
+	didValue, err := TFValToCandid(tfValue)
+	if err != nil {
+		resp.Error = function.NewFuncError(err.Error())
+		return
+	}
+
+	encoded, err := idl.Marshal([]any{didValue})
+	if err != nil {
+		resp.Error = function.NewFuncError(err.Error())
+		return
+	}
+
+	// Set the result to the same data
+	resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, hex.EncodeToString(encoded)))
+}

--- a/internal/provider/arg_encode_function_test.go
+++ b/internal/provider/arg_encode_function_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/aviate-labs/agent-go/candid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+// Checks that our provider's encoding function (tf -> candid) is equivalent
+// to (the agent-go implementation of) didc.
+func TestEncodeFunction_DidcEquivalence(t *testing.T) {
+	t.Parallel()
+
+	// Some HCL/candid pairs that should be equivalent (meaning: same encoding)
+	goldens := []struct {
+		hcl    string
+		candid string
+	}{
+		{hcl: `"test-value"`, candid: `("test-value")`},
+		{hcl: `provider::ic::did_text("test-value")`, candid: `("test-value")`},
+		{hcl: `provider::ic::did_record({ param = "val" })`, candid: `(record { param = "val" })`},
+		{hcl: `{ greeter = "hello" }`, candid: `(record { greeter = "hello" })`},
+		{
+			hcl:    `{ param1 = "val1", param2 = { param21 = "innerVal" } }`,
+			candid: `(record { param1 = "val1"; param2 = record { param21 = "innerVal" } })`,
+		},
+	}
+
+	testSteps := make([]resource.TestStep, len(goldens))
+
+	// For each golden test, create a test step that checks the
+	// result of the terraform encoding function against the didc (agent-go)
+	// equivalent.
+	// Each test step is simply an HCL config that calls the encode tf value
+	// and reads the config value output.
+	for i := 0; i < len(goldens); i++ {
+
+		encoded, err := candid.EncodeValueString(goldens[i].candid)
+		if err != nil {
+			t.Fatalf("Nope %s", err.Error())
+		}
+		didStr := hex.EncodeToString(encoded)
+		hcl := fmt.Sprintf(`
+                output "test" {
+                    value = provider::ic::did_encode(%s)
+                }`,
+			goldens[i].hcl,
+		)
+
+		testSteps[i] = resource.TestStep{
+			Config: hcl,
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownOutputValue("test", knownvalue.StringExact(didStr)),
+			},
+		}
+	}
+
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			// Provider functions are only supports in 1.8.0+
+			tfversion.SkipBelow(tfversion.Version1_8_0),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    testSteps,
+	})
+}

--- a/internal/provider/arg_record_function.go
+++ b/internal/provider/arg_record_function.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const argRecordSummary = "Mark a Terraform value as a candid record"
+
+const argRecordDescription = "See the documentation for `did_encode`."
+
+// Ensure the implementation satisfies the desired interfaces.
+var _ function.Function = &ArgRecordFunction{}
+
+type ArgRecordFunction struct{}
+
+func (f *ArgRecordFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "did_record"
+}
+
+var didRecordReturnAttrTypes = map[string]attr.Type{
+	"__didType":  types.StringType,  /* the string constant "record" */
+	"__didValue": types.DynamicType, /* the record value (object) itself */
+}
+
+func (f *ArgRecordFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+
+	resp.Definition = function.Definition{
+		Summary:             argRecordSummary,
+		Description:         argRecordDescription,
+		MarkdownDescription: argRecordDescription,
+
+		Parameters: []function.Parameter{
+			// XXX: need dynamic parameter because e.g. Map<Dynamic> is not supported
+			function.DynamicParameter{
+				Name:        "input",
+				Description: "The HCL object to candid-encoded as a candid record",
+			},
+		},
+		Return: function.ObjectReturn{
+			AttributeTypes: didRecordReturnAttrTypes,
+		},
+	}
+}
+
+func (f *ArgRecordFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var input attr.Value
+
+	// Read Terraform argument data into the variable
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &input))
+	if resp.Error != nil {
+		return
+	}
+
+	wrapped, diags := types.ObjectValue(
+		didRecordReturnAttrTypes,
+		map[string]attr.Value{
+			"__didType":  types.StringValue("record"),
+			"__didValue": types.DynamicValue(input),
+		},
+	)
+
+	resp.Error = function.FuncErrorFromDiags(ctx, diags)
+	if resp.Error != nil {
+		return
+	}
+
+	// Set the result to the same data
+	resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, wrapped))
+}

--- a/internal/provider/arg_text_function.go
+++ b/internal/provider/arg_text_function.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const argTextSummary = "Mark a Terraform value as a candid text"
+
+const argTextDescription = "See the documentation for `did_encode`."
+
+// Ensure the implementation satisfies the desired interfaces.
+var _ function.Function = &ArgTextFunction{}
+
+type ArgTextFunction struct{}
+
+func (f *ArgTextFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "did_text"
+}
+
+var didTextReturnAttrTypes = map[string]attr.Type{
+	"__didType":  types.StringType, /* the string constant "text" */
+	"__didValue": types.StringType, /* the string value itself */
+}
+
+func (f *ArgTextFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+
+	resp.Definition = function.Definition{
+		Summary:             argTextSummary,
+		Description:         argTextDescription,
+		MarkdownDescription: argTextDescription,
+
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:        "input",
+				Description: "The Terraform string to candid-encode as candid text",
+			},
+		},
+		Return: function.ObjectReturn{
+			AttributeTypes: didTextReturnAttrTypes,
+		},
+	}
+}
+
+func (f *ArgTextFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var input string
+
+	// Read Terraform argument data into the variable
+	resp.Error = function.ConcatFuncErrors(resp.Error, req.Arguments.Get(ctx, &input))
+
+	wrapped, diags := types.ObjectValue(
+		didTextReturnAttrTypes,
+		map[string]attr.Value{
+			"__didType":  types.StringValue("text"),
+			"__didValue": types.StringValue(input),
+		},
+	)
+
+	resp.Error = function.FuncErrorFromDiags(ctx, diags)
+	if resp.Error != nil {
+		return
+	}
+
+	// Set the result to the same data
+	resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, wrapped))
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -143,7 +143,17 @@ func (p *IcProvider) DataSources(ctx context.Context) []func() datasource.DataSo
 }
 
 func (p *IcProvider) Functions(ctx context.Context) []func() function.Function {
-	return []func() function.Function{}
+	return []func() function.Function{
+		func() function.Function {
+			return &ArgTextFunction{}
+		},
+		func() function.Function {
+			return &ArgRecordFunction{}
+		},
+		func() function.Function {
+			return &ArgEncodeFunction{}
+		},
+	}
 }
 
 func New(version string) func() provider.Provider {


### PR DESCRIPTION
This adds `arg` support for records (of strings & records).

The arg inference is changed a bit and tested against agent-go's `didc`-style encoding of strings (e.g. strings like `"record {...}"`).

A couple of helper functions are added to the provider. These are used to _encode_ (`did_encode`, used mostly in testing and used implicitely when using `arg`) and _annotate_ values with types (`did_text`, `did_record`) to avoid ambiguity (i.e. for soon-to-come principal support).